### PR TITLE
SOMS-36 Refactor to make more robust. Fix custId lookup for old data

### DIFF
--- a/controllers/controller_mollie_webhook.erl
+++ b/controllers/controller_mollie_webhook.erl
@@ -41,9 +41,9 @@ allowed_methods(ReqData, Context) ->
 
 process_post(ReqData, Context) ->
     Context1 = ?WM_REQ(ReqData, Context),
-    ExtId = z_convert:to_binary(z_context:get_q(id, Context1)),
-    PaymentNr = z_convert:to_binary(z_context:get_q(payment_nr, Context1)),
-    case m_payment_mollie_api:payment_sync(PaymentNr, ExtId, Context1) of
+    ExtPaymentId = z_convert:to_binary(z_context:get_q(id, Context1)),
+    FirstPaymentNr = z_convert:to_binary(z_context:get_q(payment_nr, Context1)),
+    case m_payment_mollie_api:payment_sync_webhook(FirstPaymentNr, ExtPaymentId, Context1) of
         ok ->
             ?WM_REPLY(true, Context1);
         {error, notfound} ->

--- a/mod_payment_mollie.erl
+++ b/mod_payment_mollie.erl
@@ -50,10 +50,9 @@ observe_payment_psp_view_url(#payment_psp_view_url{}, _Context) ->
 %% @doc Used to fetch the status of all payments in a non-final state. Called manually or periodically.
 observe_payment_psp_status_sync(#payment_psp_status_sync{
         payment_id = PaymentId,
-        psp_module = ?MODULE,
-        psp_external_id = TransactionId
+        psp_module = ?MODULE
     }, Context) ->
-    m_payment_mollie_api:payment_sync(PaymentId, TransactionId, Context);
+    m_payment_mollie_api:payment_sync(PaymentId, Context);
 observe_payment_psp_status_sync(#payment_psp_status_sync{}, _Context) ->
     undefined.
 
@@ -66,4 +65,5 @@ observe_cancel_recurring_psp_request(#cancel_recurring_psp_request{ user_id = Us
 %% they are newly created by the PSP and then pushed to the webhook.
 %% Non-recurring payments are synced using the psp_status_sync.
 observe_tick_24h(tick_24h, Context) ->
-    m_payment_mollie_api:payment_sync_recurrent(Context).
+    m_payment_mollie_api:payment_sync_periodic(Context),
+    m_payment_mollie_api:payment_sync_recent_pending(Context).


### PR DESCRIPTION
Make the sync of data more robust.

- Better distinction between Webhook initiated syncs and module initiated syncs
- Only create subscriptions for recent payments (fixes issues with fetches of very old data)
- Fix lookup of customerId with a mix of v1 and v2 payment data
- Renamed variables to make the code clearer