### PR TITLE
Fix for removed statuses 'refunded', 'charged_back' and 'paidout'

### DIFF
--- a/models/m_payment_mollie_api.erl
+++ b/models/m_payment_mollie_api.erl
@@ -273,7 +273,8 @@ fetch_payments_since_loop(Oldest, NextLink, Acc, Context) ->
         {ok, #{ <<"_embedded">> := #{ <<"payments">> := Payments } } = JSON} ->
             Newer = lists:filter(
                 fun(P) ->
-                    status_date(P) >= Oldest
+                    Status = payment_status(P),
+                    status_date(Status, P) >= Oldest
                 end,
                 Payments),
             Acc1 = Acc ++ Newer,
@@ -392,7 +393,6 @@ handle_payment_update(FirstPaymentId, _FirstPayment, #{ <<"sequenceType">> := <<
     % The given (first) Payment MUST have 'recurring' set.
     #{
         <<"id">> := ExtId,
-        <<"status">> := Status,
         <<"subscriptionId">> := _SubscriptionId,
         <<"amount">> := #{
             <<"currency">> := Currency,
@@ -400,9 +400,10 @@ handle_payment_update(FirstPaymentId, _FirstPayment, #{ <<"sequenceType">> := <<
         },
         <<"description">> := Description
     } = JSON,
+    Status = payment_status(JSON),
     % Create a new payment, referring to the PaymentId
     AmountNr = z_convert:to_float(Amount),
-    DateTime = z_convert:to_datetime( status_date(JSON) ),
+    DateTime = z_convert:to_datetime( status_date(Status, JSON) ),
     case m_payment:get_by_psp(mod_payment_mollie, ExtId, Context) of
         {ok, RecurringPayment} ->
             % Update the status of an already imported recurring payment.
@@ -435,10 +436,8 @@ handle_payment_update(FirstPaymentId, _FirstPayment, #{ <<"sequenceType">> := <<
     end;
 handle_payment_update(FirstPaymentId, FirstPayment, #{ <<"sequenceType">> := <<"first">> } = JSON, Context) ->
     % First recurring payment for an existing payment - if moved to paid then start the subscription
-    #{
-        <<"status">> := Status
-    } = JSON,
-    DateTime = z_convert:to_datetime( status_date(JSON) ),
+    Status = payment_status(JSON),
+    DateTime = z_convert:to_datetime( status_date(Status, JSON) ),
     {status, PrevStatus} = proplists:lookup(status, FirstPayment),
     case is_status_equal(Status, PrevStatus) of
         true ->
@@ -451,9 +450,7 @@ handle_payment_update(FirstPaymentId, FirstPayment, #{ <<"sequenceType">> := <<"
             end
     end;
 handle_payment_update(OneOffPaymentId, _OneOffPayment, JSON, Context) ->
-    #{
-        <<"status">> := Status
-    } = JSON,
+    Status = payment_status(JSON),
     lager:info("Payment PSP Mollie got status ~p for payment #~p",
                [Status, OneOffPaymentId]),
     m_payment_log:log(
@@ -466,16 +463,26 @@ handle_payment_update(OneOffPaymentId, _OneOffPayment, JSON, Context) ->
         ],
         Context),
     % UPDATE OUR ORDER STATUS
-    DateTime = z_convert:to_datetime( status_date(JSON) ),
+    DateTime = z_convert:to_datetime( status_date(Status, JSON) ),
     update_payment_status(OneOffPaymentId, Status, DateTime, Context).
 
 
-status_date(#{ <<"status">> := <<"charged_back">> }) -> calendar:universal_time();
-status_date(#{ <<"expiredAt">> := Date }) when is_binary(Date), Date =/= <<>> -> Date;
-status_date(#{ <<"failedAt">> := Date }) when is_binary(Date), Date =/= <<>> -> Date;
-status_date(#{ <<"canceledAt">> := Date }) when is_binary(Date), Date =/= <<>> -> Date;
-status_date(#{ <<"paidAt">> := Date }) when is_binary(Date), Date =/= <<>> -> Date;
-status_date(#{ <<"createdAt">> := Date }) when is_binary(Date), Date =/= <<>> -> Date.
+status_date(<<"charged_back">>, _JSON) -> calendar:universal_time();
+status_date(_Status, #{ <<"expiredAt">> := Date }) when is_binary(Date), Date =/= <<>> -> Date;
+status_date(_Status, #{ <<"failedAt">> := Date }) when is_binary(Date), Date =/= <<>> -> Date;
+status_date(_Status, #{ <<"canceledAt">> := Date }) when is_binary(Date), Date =/= <<>> -> Date;
+status_date(_Status, #{ <<"paidAt">> := Date }) when is_binary(Date), Date =/= <<>> -> Date;
+status_date(_Status, #{ <<"createdAt">> := Date }) when is_binary(Date), Date =/= <<>> -> Date.
+
+
+%% In the Mollie v2 API the statuses 'refunded', 'charged_back' and 'paidout' are removed.
+%% The final status is now 'paid'. The removed statuses need to be derived from the presence
+%% of links in the _links object.
+payment_status(#{ <<"_links">> := #{ <<"refunds">> := #{ <<"href">> := _ }} }) -> <<"refunded">>;
+payment_status(#{ <<"_links">> := #{ <<"chargebacks">> := #{ <<"href">> := _ }} }) -> <<"charged_back">>;
+payment_status(#{ <<"_links">> := #{ <<"settlement">> := #{ <<"href">> := _ }} }) -> <<"paidout">>;
+payment_status(#{ <<"status">> := Status }) -> Status.
+
 
 % Status is one of: open cancelled expired failed pending paid paidout refunded charged_back
 update_payment_status(PaymentId, <<"open">>, Date, Context) ->         mod_payment:set_payment_status(PaymentId, new, Date, Context);

--- a/models/m_payment_mollie_api.erl
+++ b/models/m_payment_mollie_api.erl
@@ -478,9 +478,9 @@ status_date(_Status, #{ <<"createdAt">> := Date }) when is_binary(Date), Date =/
 %% In the Mollie v2 API the statuses 'refunded', 'charged_back' and 'paidout' are removed.
 %% The final status is now 'paid'. The removed statuses need to be derived from the presence
 %% of links in the _links object.
-payment_status(#{ <<"_links">> := #{ <<"refunds">> := #{ <<"href">> := _ }} }) -> <<"refunded">>;
-payment_status(#{ <<"_links">> := #{ <<"chargebacks">> := #{ <<"href">> := _ }} }) -> <<"charged_back">>;
-payment_status(#{ <<"_links">> := #{ <<"settlement">> := #{ <<"href">> := _ }} }) -> <<"paidout">>;
+payment_status(#{ <<"status">> := <<"paid">>, <<"_links">> := #{ <<"chargebacks">> := #{ <<"href">> := _ }}}) -> <<"charged_back">>;
+payment_status(#{ <<"status">> := <<"paid">>, <<"_links">> := #{ <<"refunds">> := #{ <<"href">> := _ }}}) -> <<"refunded">>;
+payment_status(#{ <<"status">> := <<"paid">>, <<"_links">> := #{ <<"settlement">> := #{ <<"href">> := _ }}}) -> <<"paidout">>;
 payment_status(#{ <<"status">> := Status }) -> Status.
 
 


### PR DESCRIPTION
In the Mollie v2 API the statuses 'refunded', 'charged_back' and 'paidout' are removed.

The final status is now 'paid'. The removed statuses need to be derived from the presence of links in the _links object.